### PR TITLE
Fixed client crash when unkown alert status was returned from DB

### DIFF
--- a/client/sguil.tk
+++ b/client/sguil.tk
@@ -702,7 +702,7 @@ proc InsertEventQueryResults { paneName results } {
 
     } else {
 
-	if { [catch { set statusColor [lindex $CAT($status) 2]}]} { set statusColor "#9633FF"}
+        if { [catch { set statusColor [lindex $CAT($status) 2]}]} { set statusColor "#9633FF"}
         if { [catch { set statusName [lindex $CAT($status) 1] }]} { set statusName UNK }
 
     }

--- a/client/sguil.tk
+++ b/client/sguil.tk
@@ -702,8 +702,8 @@ proc InsertEventQueryResults { paneName results } {
 
     } else {
 
-        set statusColor [lindex $CAT($status) 2]
-        set statusName [lindex $CAT($status) 1]
+	if { [catch { set statusColor [lindex $CAT($status) 2]}]} { set statusColor "#9633FF"}
+        if { [catch { set statusName [lindex $CAT($status) 1] }]} { set statusName UNK }
 
     }
 


### PR DESCRIPTION
Created a catch block when an unknown alert status is returned from the DB sets the Message to "UNK" and the color to purple.
